### PR TITLE
Add fluid power unit conversions tab

### DIFF
--- a/index.html
+++ b/index.html
@@ -17,6 +17,7 @@
   <div class="tabs" role="tablist" aria-label="Tool categories">
     <div class="tab active" role="tab" tabindex="0" aria-selected="true" aria-controls="panel-pressure-drop" id="tab-pressure-drop">Pressure Drop</div>
     <div class="tab" role="tab" tabindex="-1" aria-selected="false" aria-controls="panel-flow-conversion" id="tab-flow-conversion">Flow Conversion</div>
+    <div class="tab" role="tab" tabindex="-1" aria-selected="false" aria-controls="panel-unit-conversions" id="tab-unit-conversions">Unit Conversions</div>
     <div class="tab" role="tab" tabindex="-1" aria-selected="false" aria-controls="panel-cylinder-force" id="tab-cylinder-force">Cylinder Force</div>
     <div class="tab" role="tab" tabindex="-1" aria-selected="false" aria-controls="panel-pump-power" id="tab-pump-power">Pump Power</div>
     <div class="tab" role="tab" tabindex="-1" aria-selected="false" aria-controls="panel-bom-comparator" id="tab-bom-comparator">BOM Comparator</div>
@@ -61,12 +62,36 @@
       <option value="cms">CMS (Cubic Meters/sec)</option>
     </select>
 
-    <button id="convertFlowBtn">Convert</button>
-    <div id="flowConvertResult"></div>
-  </section>
+  <button id="convertFlowBtn">Convert</button>
+  <div id="flowConvertResult"></div>
+</section>
 
-  <!-- Cylinder Force -->
-  <section id="panel-cylinder-force" class="tab-panel" role="tabpanel" aria-labelledby="tab-cylinder-force" tabindex="0">
+<!-- Unit Conversions -->
+<section id="panel-unit-conversions" class="tab-panel" role="tabpanel" aria-labelledby="tab-unit-conversions" tabindex="0">
+  <label class="calc-label" for="ucCategory">Conversion Type:</label>
+  <select id="ucCategory">
+    <option value="pressure">Pressure</option>
+    <option value="force">Force</option>
+    <option value="power">Power</option>
+    <option value="length">Length</option>
+    <option value="torque">Torque</option>
+  </select>
+
+  <label class="calc-label" for="ucValue">Value:</label>
+  <input type="number" id="ucValue" min="0" step="any" />
+
+  <label class="calc-label" for="ucFromUnit">From Unit:</label>
+  <select id="ucFromUnit"></select>
+
+  <label class="calc-label" for="ucToUnit">To Unit:</label>
+  <select id="ucToUnit"></select>
+
+  <button id="convertUnitBtn">Convert</button>
+  <div id="unitConvertResult"></div>
+</section>
+
+<!-- Cylinder Force -->
+<section id="panel-cylinder-force" class="tab-panel" role="tabpanel" aria-labelledby="tab-cylinder-force" tabindex="0">
     <label class="calc-label" for="cylBoreDiameter">Cylinder Bore Diameter (inches):</label>
     <input type="number" id="cylBoreDiameter" min="0" step="any" />
 

--- a/script.js
+++ b/script.js
@@ -101,6 +101,57 @@
     return converted.toFixed(4);
   }
 
+  // General Unit Conversions
+  const unitConversionData = {
+    pressure: {
+      units: {
+        psi: { label: 'PSI', toBase: 1 },
+        bar: { label: 'Bar', toBase: 14.5038 },
+        kpa: { label: 'kPa', toBase: 0.145038 }
+      }
+    },
+    force: {
+      units: {
+        lbf: { label: 'Pound-force (lbf)', toBase: 1 },
+        n: { label: 'Newton (N)', toBase: 0.224809 }
+      }
+    },
+    power: {
+      units: {
+        hp: { label: 'Horsepower (HP)', toBase: 1 },
+        kw: { label: 'Kilowatt (kW)', toBase: 1.34102 },
+        w: { label: 'Watt (W)', toBase: 0.00134102 }
+      }
+    },
+    length: {
+      units: {
+        in: { label: 'Inch (in)', toBase: 1 },
+        ft: { label: 'Foot (ft)', toBase: 12 },
+        mm: { label: 'Millimeter (mm)', toBase: 0.0393701 },
+        m: { label: 'Meter (m)', toBase: 39.3701 }
+      }
+    },
+    torque: {
+      units: {
+        ftlb: { label: 'Foot-pound (ft·lbf)', toBase: 1 },
+        inlb: { label: 'Inch-pound (in·lbf)', toBase: 0.0833333 },
+        nm: { label: 'Newton-meter (N·m)', toBase: 0.737562 }
+      }
+    }
+  };
+
+  function convertUnits(value, category, fromUnit, toUnit) {
+    if (value <= 0) return null;
+    const cat = unitConversionData[category];
+    if (!cat) return null;
+    const from = cat.units[fromUnit];
+    const to = cat.units[toUnit];
+    if (!from || !to) return null;
+    const baseValue = value * from.toBase;
+    const converted = baseValue / to.toBase;
+    return converted.toFixed(4);
+  }
+
   // Cylinder Force (lbf)
   // Force = Pressure (psi) * Area (in^2)
   function calculateCylinderForce(boreDiameterIn, pressurePsi) {
@@ -137,6 +188,40 @@
     const to = document.getElementById('flowUnitTo').value;
     const result = convertFlow(val, from, to);
     document.getElementById('flowConvertResult').textContent = result !== null ? result + ' ' + to.toUpperCase() : 'Invalid input';
+  });
+
+  const ucCategoryEl = document.getElementById('ucCategory');
+  const ucFromUnitEl = document.getElementById('ucFromUnit');
+  const ucToUnitEl = document.getElementById('ucToUnit');
+
+  function populateUnitSelects() {
+    const category = ucCategoryEl.value;
+    const units = unitConversionData[category].units;
+    ucFromUnitEl.innerHTML = '';
+    ucToUnitEl.innerHTML = '';
+    Object.keys(units).forEach(key => {
+      const label = units[key].label;
+      const optFrom = document.createElement('option');
+      optFrom.value = key;
+      optFrom.textContent = label;
+      ucFromUnitEl.appendChild(optFrom);
+      const optTo = document.createElement('option');
+      optTo.value = key;
+      optTo.textContent = label;
+      ucToUnitEl.appendChild(optTo);
+    });
+  }
+
+  ucCategoryEl.addEventListener('change', populateUnitSelects);
+  populateUnitSelects();
+
+  document.getElementById('convertUnitBtn').addEventListener('click', () => {
+    const val = parseFloat(document.getElementById('ucValue').value);
+    const category = ucCategoryEl.value;
+    const from = ucFromUnitEl.value;
+    const to = ucToUnitEl.value;
+    const result = convertUnits(val, category, from, to);
+    document.getElementById('unitConvertResult').textContent = result !== null ? result + ' ' + to.toUpperCase() : 'Invalid input';
   });
 
   document.getElementById('calcCylinderForceBtn').addEventListener('click', () => {

--- a/styles.css
+++ b/styles.css
@@ -108,7 +108,7 @@
   .calc-label {
     margin-top: 15px;
   }
-  #result, #flowConvertResult, #cylinderForceResult, #pumpPowerResult, #pressureDropResult {
+  #result, #flowConvertResult, #cylinderForceResult, #pumpPowerResult, #pressureDropResult, #unitConvertResult {
     font-weight: 700;
     font-size: 1.2rem;
     color: #2c3e50;


### PR DESCRIPTION
## Summary
- add Unit Conversions tab for pressure, force, power, length, and torque
- implement generic unit conversion logic in JS
- style output for new conversion result

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a88bf4e428832fbf81eb61488c9c58