### PR TITLE
Consolidate flow conversions and add reference tab

### DIFF
--- a/index.html
+++ b/index.html
@@ -16,11 +16,11 @@
 
   <div class="tabs" role="tablist" aria-label="Tool categories">
     <div class="tab active" role="tab" tabindex="0" aria-selected="true" aria-controls="panel-pressure-drop" id="tab-pressure-drop">Pressure Drop</div>
-    <div class="tab" role="tab" tabindex="-1" aria-selected="false" aria-controls="panel-flow-conversion" id="tab-flow-conversion">Flow Conversion</div>
     <div class="tab" role="tab" tabindex="-1" aria-selected="false" aria-controls="panel-unit-conversions" id="tab-unit-conversions">Unit Conversions</div>
     <div class="tab" role="tab" tabindex="-1" aria-selected="false" aria-controls="panel-cylinder-force" id="tab-cylinder-force">Cylinder Force</div>
     <div class="tab" role="tab" tabindex="-1" aria-selected="false" aria-controls="panel-pump-power" id="tab-pump-power">Pump Power</div>
     <div class="tab" role="tab" tabindex="-1" aria-selected="false" aria-controls="panel-bom-comparator" id="tab-bom-comparator">BOM Comparator</div>
+    <div class="tab" role="tab" tabindex="-1" aria-selected="false" aria-controls="panel-reference" id="tab-reference">📊 Reference &amp; Lookup</div>
   </div>
 
   <!-- Pressure Drop -->
@@ -37,41 +37,18 @@
     <label class="calc-label" for="pdViscosity">Dynamic Viscosity (cP):</label>
     <input type="number" id="pdViscosity" min="0" step="any" value="40" />
 
-    <button id="calcPressureDrop">Calculate Pressure Drop (psi)</button>
+    <div class="button-row">
+      <button id="calcPressureDrop">Calculate Pressure Drop (psi)</button>
+      <button id="clearPressureDrop">Clear</button>
+    </div>
     <div id="pressureDropResult"></div>
-    <button id="clearPressureDrop">Clear</button>
   </section>
-
-  <!-- Flow Conversion -->
-  <section id="panel-flow-conversion" class="tab-panel" role="tabpanel" aria-labelledby="tab-flow-conversion" tabindex="0">
-    <label class="calc-label" for="flowInput">Flow Rate:</label>
-    <input type="number" id="flowInput" min="0" step="any" />
-
-    <label class="calc-label" for="flowUnit">From Unit:</label>
-    <select id="flowUnit">
-      <option value="gpm">GPM (US Gallons/min)</option>
-      <option value="lpm">LPM (Liters/min)</option>
-      <option value="cfm">CFM (Cubic Feet/min)</option>
-      <option value="cms">CMS (Cubic Meters/sec)</option>
-    </select>
-
-    <label class="calc-label" for="flowUnitTo">To Unit:</label>
-    <select id="flowUnitTo">
-      <option value="gpm">GPM (US Gallons/min)</option>
-      <option value="lpm">LPM (Liters/min)</option>
-      <option value="cfm">CFM (Cubic Feet/min)</option>
-      <option value="cms">CMS (Cubic Meters/sec)</option>
-    </select>
-
-  <button id="convertFlowBtn">Convert</button>
-  <div id="flowConvertResult"></div>
-  <button id="clearFlowConvert">Clear</button>
-</section>
 
 <!-- Unit Conversions -->
 <section id="panel-unit-conversions" class="tab-panel" role="tabpanel" aria-labelledby="tab-unit-conversions" tabindex="0">
   <label class="calc-label" for="ucCategory">Conversion Type:</label>
   <select id="ucCategory">
+    <option value="flow">Flow</option>
     <option value="pressure">Pressure</option>
     <option value="force">Force</option>
     <option value="power">Power</option>
@@ -86,9 +63,11 @@
   <label class="calc-label" for="ucToUnit">To Unit:</label>
   <select id="ucToUnit"></select>
 
-  <button id="convertUnitBtn">Convert</button>
+  <div class="button-row">
+    <button id="convertUnitBtn">Convert</button>
+    <button id="clearUnitConvert">Clear</button>
+  </div>
   <div id="unitConvertResult"></div>
-  <button id="clearUnitConvert">Clear</button>
 </section>
 
 <!-- Cylinder Force -->
@@ -99,9 +78,11 @@
     <label class="calc-label" for="cylPressure">Pressure (psi):</label>
     <input type="number" id="cylPressure" min="0" step="any" />
 
-    <button id="calcCylinderForceBtn">Calculate Force (lbf)</button>
+    <div class="button-row">
+      <button id="calcCylinderForceBtn">Calculate Force (lbf)</button>
+      <button id="clearCylinderForce">Clear</button>
+    </div>
     <div id="cylinderForceResult"></div>
-    <button id="clearCylinderForce">Clear</button>
   </section>
 
   <!-- Pump Power -->
@@ -115,9 +96,11 @@
     <label class="calc-label" for="pumpEfficiency">Efficiency (%):</label>
     <input type="number" id="pumpEfficiency" min="1" max="100" step="any" value="85" />
 
-    <button id="calcPumpPowerBtn">Calculate Power (HP)</button>
+    <div class="button-row">
+      <button id="calcPumpPowerBtn">Calculate Power (HP)</button>
+      <button id="clearPumpPower">Clear</button>
+    </div>
     <div id="pumpPowerResult"></div>
-    <button id="clearPumpPower">Clear</button>
   </section>
 
   <!-- BOM Comparator -->
@@ -157,6 +140,16 @@
     </div>
 
     <div id="bomResults" aria-live="polite" aria-atomic="true" style="margin-top: 35px;"></div>
+  </section>
+
+  <!-- Reference & Lookup -->
+  <section id="panel-reference" class="tab-panel" role="tabpanel" aria-labelledby="tab-reference" tabindex="0">
+    <ul>
+      <li>Fitting identification (Brennan model codes, thread ID charts)</li>
+      <li>Hose dash size charts (dash ↔ ID in inches/mm)</li>
+      <li>Common seal/gland dimensions (Parker O-ring sizes)</li>
+      <li>Hydraulic symbol library</li>
+    </ul>
   </section>
 </div>
 

--- a/script.js
+++ b/script.js
@@ -61,7 +61,7 @@
     });
   });
 
-  const resultIds = ['pressureDropResult','flowConvertResult','unitConvertResult','cylinderForceResult','pumpPowerResult','bomResults'];
+  const resultIds = ['pressureDropResult','unitConvertResult','cylinderForceResult','pumpPowerResult','bomResults'];
   resultIds.forEach(id => {
     const el = document.getElementById(id);
     const stored = localStorage.getItem(id);
@@ -112,30 +112,16 @@
     return deltaPsi.toFixed(2);
   }
 
-  // Flow conversion
-  const flowConversions = {
-    gpm: 1,
-    lpm: 3.78541,
-    cfm: 0.133681,
-    cms: 0.00006309
-  };
-
-  function convertFlow(value, fromUnit, toUnit) {
-    if (value <= 0) return null;
-    // Convert input to GPM first
-    let valueInGPM = value;
-    if (fromUnit !== 'gpm') {
-      if (!flowConversions[fromUnit]) return null;
-      valueInGPM = value / flowConversions[fromUnit];
-    }
-    // Convert from GPM to desired unit
-    if (!flowConversions[toUnit]) return null;
-    const converted = valueInGPM * flowConversions[toUnit];
-    return converted.toFixed(4);
-  }
-
   // General Unit Conversions
   const unitConversionData = {
+    flow: {
+      units: {
+        gpm: { label: 'GPM (US Gallons/min)', toBase: 1 },
+        lpm: { label: 'LPM (Liters/min)', toBase: 0.264172 },
+        cfm: { label: 'CFM (Cubic Feet/min)', toBase: 7.48052 },
+        cms: { label: 'CMS (Cubic Meters/sec)', toBase: 15850.3 }
+      }
+    },
     pressure: {
       units: {
         psi: { label: 'PSI', toBase: 1 },
@@ -210,24 +196,6 @@
     localStorage.removeItem('pressureDropResult');
   });
 
-  document.getElementById('convertFlowBtn').addEventListener('click', () => {
-    const val = parseFloat(document.getElementById('flowInput').value);
-    const from = document.getElementById('flowUnit').value;
-    const to = document.getElementById('flowUnitTo').value;
-    const result = convertFlow(val, from, to);
-    const txt = result !== null ? result + ' ' + to.toUpperCase() : 'Invalid input';
-    document.getElementById('flowConvertResult').textContent = txt;
-    localStorage.setItem('flowConvertResult', txt);
-  });
-
-  document.getElementById('clearFlowConvert').addEventListener('click', () => {
-    document.getElementById('flowInput').value = '';
-    document.getElementById('flowUnit').value = 'gpm';
-    document.getElementById('flowUnitTo').value = 'gpm';
-    ['flowInput','flowUnit','flowUnitTo','flowConvertResult'].forEach(k => localStorage.removeItem(k));
-    document.getElementById('flowConvertResult').textContent = '';
-  });
-
   const ucCategoryEl = document.getElementById('ucCategory');
   const ucFromUnitEl = document.getElementById('ucFromUnit');
   const ucToUnitEl = document.getElementById('ucToUnit');
@@ -270,7 +238,7 @@
 
   document.getElementById('clearUnitConvert').addEventListener('click', () => {
     ['ucCategory','ucValue','ucFromUnit','ucToUnit','unitConvertResult'].forEach(k => localStorage.removeItem(k));
-    ucCategoryEl.value = 'pressure';
+    ucCategoryEl.value = 'flow';
     document.getElementById('ucValue').value = '';
     populateUnitSelects();
     document.getElementById('unitConvertResult').textContent = '';

--- a/styles.css
+++ b/styles.css
@@ -105,14 +105,19 @@
     background: #1f618d;
     box-shadow: 0 8px 20px rgba(31, 97, 141, 0.6);
   }
+  .button-row {
+    display: flex;
+    gap: 15px;
+    margin-top: 10px;
+  }
   .calc-label {
     margin-top: 15px;
   }
-  #result, #flowConvertResult, #cylinderForceResult, #pumpPowerResult, #pressureDropResult, #unitConvertResult {
-    font-weight: 700;
-    font-size: 1.2rem;
-    color: #2c3e50;
-    min-height: 40px;
+    #result, #cylinderForceResult, #pumpPowerResult, #pressureDropResult, #unitConvertResult {
+      font-weight: 700;
+      font-size: 1.2rem;
+      color: #2c3e50;
+      min-height: 40px;
     margin-top: 12px;
   }
   hr {


### PR DESCRIPTION
## Summary
- Merge flow rate conversions into the Unit Conversions tool and drop the separate Flow Conversion tab
- Position Clear buttons beside their corresponding action buttons for a cleaner layout
- Introduce a new "📊 Reference & Lookup" tab with quick reference resources

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a8938ac114832f9d417aa62efd5b9a