### PR TITLE
Improve mobile responsiveness

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -284,6 +284,18 @@ th.sort-desc::after {
     flex-direction: column;
   }
 
+  .tab {
+    font-size: 0.95rem;
+  }
+
+  h3 {
+    font-size: 1.5rem;
+  }
+
+  button {
+    width: 100%;
+  }
+
   .button-row {
     flex-direction: column;
     gap: 10px;


### PR DESCRIPTION
## Summary
- Refine small-screen styles for better mobile layout
- Reduce heading and tab font sizes and make buttons full width on narrow viewports

## Testing
- `npm test` *(fails: ENOENT could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a89b099900832f84964301aeb7094b