### PR TITLE
Improve mobile responsiveness

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -281,10 +281,12 @@ th.sort-desc::after {
   }
 
   .tabs {
-    flex-direction: column;
+    flex-wrap: wrap;
   }
 
   .tab {
+    flex: 1 1 45%;
+    justify-content: center;
     font-size: 0.95rem;
   }
 


### PR DESCRIPTION
## Summary
- Allow tabs to wrap and center on small screens to prevent overflow and improve readability.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a89befef14832f80bae8777daa7f62