### PR TITLE
Add Part Lookup tab with wildcard search

### DIFF
--- a/index.html
+++ b/index.html
@@ -67,6 +67,16 @@
           role="tab"
           tabindex="-1"
           aria-selected="false"
+          aria-controls="panel-part-lookup"
+          id="tab-part-lookup"
+        >
+          Part Lookup
+        </div>
+        <div
+          class="tab"
+          role="tab"
+          tabindex="-1"
+          aria-selected="false"
           aria-controls="panel-reference"
           id="tab-reference"
         >
@@ -279,6 +289,26 @@
           aria-atomic="true"
           style="margin-top: 35px"
         ></div>
+      </section>
+      <!-- Part Lookup -->
+      <section
+        id="panel-part-lookup"
+        class="tab-panel"
+        role="tabpanel"
+        aria-labelledby="tab-part-lookup"
+        tabindex="0"
+      >
+        <label class="calc-label" for="plPart">Part Number:</label>
+        <input type="text" id="plPart" />
+
+        <label class="calc-label" for="plDesc">Description:</label>
+        <input type="text" id="plDesc" />
+
+        <div class="button-row">
+          <button id="lookupPart">Search</button>
+          <button id="clearPartLookup">Clear</button>
+        </div>
+        <div id="partLookupResults"></div>
       </section>
       <!-- Reference -->
       <section

--- a/styles.css
+++ b/styles.css
@@ -157,6 +157,9 @@ textarea:focus {
   border-radius: 6px;
   box-shadow: inset 0 0 5px #ddd;
 }
+#partLookupResults {
+  margin-top: 25px;
+}
 table {
   width: 100%;
   border-collapse: collapse;


### PR DESCRIPTION
## Summary
- add Part Lookup tab with search by part number or description using wildcards
- load items from `items_export_slim.json` and display matches
- store results locally and add basic styling for lookup results

## Testing
- `node --check script.js`
- `npx htmlhint index.html` *(fails: 403 Forbidden)*
- `npx stylelint styles.css` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68a8a5095324832f8bf44a490e1c3c14