### PR TITLE
Wrap tool tabs so they stay within layout

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -33,12 +33,14 @@ h3 {
 /* Tabs container */
 .tabs {
   display: flex;
+  flex-wrap: wrap;
   gap: 8px;
   margin-bottom: 25px;
   user-select: none;
+  justify-content: center;
 }
 .tab {
-  flex: 1;
+  flex: 1 1 150px;
   background: #2980b9;
   color: white;
   padding: 10px 10px;
@@ -49,6 +51,7 @@ h3 {
   transition: background 0.3s ease;
   display: flex;
   align-items: center;
+  justify-content: center;
 }
 .tab:hover {
   background: #1f618d;


### PR DESCRIPTION
## Summary
- Allow tool tabs to wrap and center across multiple rows
- Set a min width for each tab and center the label text

## Testing
- `npx htmlhint index.html` *(fails: 403 Forbidden - GET https://registry.npmjs.org/htmlhint)*
- `npx stylelint styles.css` *(fails: 403 Forbidden - GET https://registry.npmjs.org/stylelint)*

------
https://chatgpt.com/codex/tasks/task_e_68ac7cccb194832f968413a28120d649