### PR TITLE
Add length conversions to unit converter

### DIFF
--- a/index.html
+++ b/index.html
@@ -129,6 +129,7 @@
           <option value="pressure">Pressure</option>
           <option value="force">Force</option>
           <option value="power">Power</option>
+          <option value="length">Length</option>
         </select>
 
         <label class="calc-label" for="ucValue">Value:</label>

--- a/script.js
+++ b/script.js
@@ -172,6 +172,14 @@
         hp: { label: 'Horsepower (HP)', toBase: 1 },
         kw: { label: 'Kilowatt (kW)', toBase: 1.34102 }
       }
+    },
+    length: {
+      units: {
+        in: { label: 'Inches (in)', toBase: 1 },
+        ft: { label: 'Feet (ft)', toBase: 12 },
+        mm: { label: 'Millimeters (mm)', toBase: 0.0393701 },
+        m: { label: 'Meters (m)', toBase: 39.3701 }
+      }
     }
   };
 


### PR DESCRIPTION
## Summary
- extend unit conversion data with length units (in, ft, mm, m)
- expose new length option in converter dropdown

## Testing
- `npx htmlhint index.html` *(fails: 403 Forbidden from npm registry)*
- `npx stylelint styles.css` *(fails: 403 Forbidden from npm registry)*

------
https://chatgpt.com/codex/tasks/task_e_68ac866d2eb8832f84b58fbb81a57036