### PR TITLE
Enable enter key actions and disable part lookup autofill

### DIFF
--- a/index.html
+++ b/index.html
@@ -300,10 +300,10 @@
         tabindex="0"
       >
         <label class="calc-label" for="plPart">Part Number:</label>
-        <input type="text" id="plPart" />
+        <input type="text" id="plPart" autocomplete="off" />
 
         <label class="calc-label" for="plDesc">Description:</label>
-        <input type="text" id="plDesc" />
+        <input type="text" id="plDesc" autocomplete="off" />
 
         <div class="button-row">
           <button id="lookupPart">Search</button>

--- a/script.js
+++ b/script.js
@@ -338,6 +338,19 @@
   const plDesc = document.getElementById('plDesc');
   const partLookupResults = document.getElementById('partLookupResults');
 
+  function triggerOnEnter(ids, buttonId) {
+    ids.forEach(id => {
+      const el = document.getElementById(id);
+      if (!el) return;
+      el.addEventListener('keydown', e => {
+        if (e.key === 'Enter') {
+          e.preventDefault();
+          document.getElementById(buttonId).click();
+        }
+      });
+    });
+  }
+
   if (bomResults.innerHTML.trim()) {
     showExtras();
   }
@@ -530,3 +543,18 @@
       localStorage.removeItem(k);
     });
   });
+
+  triggerOnEnter(
+    ['pdFlow','pdDiameter','pdLength','pdViscosity'],
+    'calcPressureDrop'
+  );
+  triggerOnEnter(['ucValue'], 'convertUnitBtn');
+  triggerOnEnter(
+    ['cylBoreDiameter','cylPressure'],
+    'calcCylinderForceBtn'
+  );
+  triggerOnEnter(
+    ['pumpFlow','pumpPressure','pumpEfficiency'],
+    'calcPumpPowerBtn'
+  );
+  triggerOnEnter(['plPart','plDesc'], 'lookupPart');


### PR DESCRIPTION
## Summary
- Add `triggerOnEnter` helper to activate tool calculations with Enter key
- Disable browser autofill for part lookup fields

## Testing
- ⚠️ `npx htmlhint@latest index.html` (403 Forbidden - registry.npmjs.org)
- ⚠️ `npx stylelint@latest styles.css` (403 Forbidden - registry.npmjs.org)


------
https://chatgpt.com/codex/tasks/task_e_68acc1366fbc832f8c5e2b29e39709a5