### PR TITLE
Make reference table rows readable

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -282,7 +282,7 @@ th.sort-desc::after {
   width: 100%;
   border-collapse: collapse;
   background: white;
-  color: #fff;
+  color: #333;
 }
 
 .reference-table th,
@@ -294,10 +294,11 @@ th.sort-desc::after {
 
 .reference-table th {
   background: #111;
+  color: #fff;
 }
 
-.reference-table tbody tr:nth-child(even) {
-  background: #1a1a1a;
+.reference-table tr:nth-child(even) {
+  background: white;
 }
 
 @media (max-width: 600px) {


### PR DESCRIPTION
## Summary
- Set reference table text to dark gray and removed alternating dark row backgrounds so all rows remain white and legible

## Testing
- `npx htmlhint index.html` *(fails: 403 Forbidden - GET https://registry.npmjs.org/htmlhint)*
- `npx stylelint styles.css` *(fails: 403 Forbidden - GET https://registry.npmjs.org/stylelint)*

------
https://chatgpt.com/codex/tasks/task_e_68ae1a14b3e8832faff51aa065c3e789