### PR TITLE
Embed Spudnik fuzzy lookup

### DIFF
--- a/index.html
+++ b/index.html
@@ -329,14 +329,21 @@
         aria-labelledby="tab-part-lookup-fuzzy"
         tabindex="0"
       >
-        <label class="calc-label" for="plFuzzyQuery">Search:</label>
-        <input type="text" id="plFuzzyQuery" autocomplete="off" />
-
-        <div class="button-row">
-          <button id="lookupPartFuzzy">Search</button>
-          <button id="clearPartLookupFuzzy">Clear</button>
+        <div class="topbar">
+          <span class="hint"
+            >Tip: try "jic -08 elbow" or a full PN</span
+          >
+          <button id="fuzzyExport">Export results (CSV)</button>
         </div>
-        <div id="partLookupFuzzyResults"></div>
+        <div class="searchbar">
+          <input
+            id="fuzzyQuery"
+            placeholder="Search part number, dash size, thread type, or description…"
+            autocomplete="off"
+          />
+        </div>
+        <div id="fuzzyStats" class="meta"></div>
+        <div id="fuzzyResults" class="results"></div>
       </section>
       <!-- Reference -->
       <section
@@ -436,7 +443,6 @@
       </section>
     </div>
 
-    <script src="https://cdn.jsdelivr.net/npm/fuse.js@6.6.2/dist/fuse.min.js"></script>
     <script src="script.js"></script>
   </body>
 </html>

--- a/styles.css
+++ b/styles.css
@@ -70,6 +70,55 @@ h3 {
   display: block;
 }
 
+/* Fuzzy part lookup styles */
+#panel-part-lookup-fuzzy .topbar {
+  display: flex;
+  gap: 10px;
+  align-items: center;
+  flex-wrap: wrap;
+  margin-top: 8px;
+}
+#panel-part-lookup-fuzzy .hint {
+  font-size: 0.875rem;
+  color: #555;
+}
+#panel-part-lookup-fuzzy .searchbar {
+  display: flex;
+  gap: 12px;
+  align-items: center;
+  margin-top: 10px;
+}
+#panel-part-lookup-fuzzy .searchbar input {
+  flex: 1;
+  padding: 12px 14px;
+  border: 1px solid #d1d9e6;
+  border-radius: 6px;
+}
+#panel-part-lookup-fuzzy .results {
+  margin-top: 14px;
+}
+#panel-part-lookup-fuzzy .row {
+  background: #f9f9f9;
+  border: 1px solid #d1d9e6;
+  border-radius: 6px;
+  padding: 10px 12px;
+  margin: 10px 0;
+}
+#panel-part-lookup-fuzzy .meta {
+  font-size: 0.875rem;
+  color: #555;
+  margin-top: 4px;
+}
+#panel-part-lookup-fuzzy .score {
+  font-variant-numeric: tabular-nums;
+  color: #888;
+  font-size: 0.75rem;
+}
+#panel-part-lookup-fuzzy button {
+  padding: 6px 10px;
+  font-size: 0.875rem;
+}
+
 /* --- Calculator common styles --- */
 label {
   font-weight: 600;


### PR DESCRIPTION
## Summary
- inline Spudnik fuzzy part search UI within the fuzzy lookup tab
- port search algorithm and CSV export hooked to repository's item database
- style embedded lookup interface to match existing layout

## Testing
- `node --check script.js`
- `npx htmlhint index.html` *(fails: 403 Forbidden)*
- `npx stylelint styles.css` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68b0d11c441c832f89f3fed96f81a150