### PR TITLE
Hide empty fuzzy BOM list until items added

### DIFF
--- a/index.html
+++ b/index.html
@@ -360,11 +360,11 @@
         aria-labelledby="tab-part-lookup-fuzzy-bom"
         tabindex="0"
       >
-        <div class="topbar">
+        <div class="topbar" style="display: none;">
           <button id="fuzzyBomExport">Export results (CSV)</button>
           <button id="fuzzyBomClear">Clear BOM</button>
         </div>
-        <div id="fuzzyBomList" class="bom"></div>
+        <div id="fuzzyBomList" class="bom" style="display: none"></div>
         <div class="searchbar">
           <input
             id="fuzzyBomQuery"

--- a/script.js
+++ b/script.js
@@ -594,6 +594,9 @@
   const fuzzyBomResultsEl = document.getElementById('fuzzyBomResults');
   const fuzzyBomStatsEl = document.getElementById('fuzzyBomStats');
   const fuzzyBomListEl = document.getElementById('fuzzyBomList');
+  const fuzzyBomTopbarEl = document.querySelector(
+    '#panel-part-lookup-fuzzy-bom .topbar'
+  );
   const fuzzyBomExportBtn = document.getElementById('fuzzyBomExport');
   const fuzzyBomClearBtn = document.getElementById('fuzzyBomClear');
   let fuzzyBomLast = [];
@@ -702,14 +705,21 @@
   }
 
   function renderBom() {
-    if (!fuzzyBomListEl) return;
+    if (!fuzzyBomListEl || !fuzzyBomTopbarEl) return;
     fuzzyBomListEl.innerHTML = '';
-    for (const item of fuzzyBom) {
-      const div = document.createElement('div');
-      const safe = (item.desc || '').replace(/</g, '&lt;');
-      div.innerHTML = `<strong>${item.pn || ''}</strong> ` +
-        `<span class="meta">${safe}</span>`;
-      fuzzyBomListEl.appendChild(div);
+    if (!fuzzyBom.length) {
+      fuzzyBomTopbarEl.style.display = 'none';
+      fuzzyBomListEl.style.display = 'none';
+    } else {
+      fuzzyBomTopbarEl.style.display = '';
+      fuzzyBomListEl.style.display = '';
+      for (const item of fuzzyBom) {
+        const div = document.createElement('div');
+        const safe = (item.desc || '').replace(/</g, '&lt;');
+        div.innerHTML = `<strong>${item.pn || ''}</strong> ` +
+          `<span class="meta">${safe}</span>`;
+        fuzzyBomListEl.appendChild(div);
+      }
     }
     localStorage.setItem('fuzzyBom', JSON.stringify(fuzzyBom));
   }


### PR DESCRIPTION
## Summary
- Hide fuzzy BOM top bar and list by default in Part Lookup (Fuzzy BOM) section
- Toggle BOM controls visibility based on whether items exist in BOM

## Testing
- `npx --yes htmlhint index.html 2>&1` *(fails: 403 Forbidden)*
- `npx --yes stylelint styles.css 2>&1` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68b84a2d93a8832f8a39bbcb19376234