### PR TITLE
Fix fuzzy BOM list visibility

### DIFF
--- a/index.html
+++ b/index.html
@@ -364,7 +364,7 @@
           <button id="fuzzyBomExport">Export results (CSV)</button>
           <button id="fuzzyBomClear">Clear BOM</button>
         </div>
-        <div id="fuzzyBomList" class="bom" style="display: none"></div>
+        <div id="fuzzyBomList" class="bom"></div>
         <div class="searchbar">
           <input
             id="fuzzyBomQuery"

--- a/script.js
+++ b/script.js
@@ -707,20 +707,14 @@
   function renderBom() {
     if (!fuzzyBomListEl || !fuzzyBomTopbarEl) return;
     fuzzyBomListEl.innerHTML = '';
-    if (!fuzzyBom.length) {
-      fuzzyBomTopbarEl.style.display = 'none';
-      fuzzyBomListEl.style.display = 'none';
-    } else {
-      fuzzyBomTopbarEl.style.display = '';
-      fuzzyBomListEl.style.display = '';
-      for (const item of fuzzyBom) {
-        const div = document.createElement('div');
-        const safe = (item.desc || '').replace(/</g, '&lt;');
-        div.innerHTML = `<strong>${item.pn || ''}</strong> ` +
-          `<span class="meta">${safe}</span>`;
-        fuzzyBomListEl.appendChild(div);
-      }
+    for (const item of fuzzyBom) {
+      const div = document.createElement('div');
+      const safe = (item.desc || '').replace(/</g, '&lt;');
+      div.innerHTML = `<strong>${item.pn || ''}</strong> ` +
+        `<span class="meta">${safe}</span>`;
+      fuzzyBomListEl.appendChild(div);
     }
+    fuzzyBomTopbarEl.style.display = fuzzyBom.length ? 'flex' : 'none';
     localStorage.setItem('fuzzyBom', JSON.stringify(fuzzyBom));
   }
 


### PR DESCRIPTION
## Summary
- show fuzzy BOM list container by default
- toggle top bar only when items exist to keep BOM box visible
- allow items to be added again

## Testing
- `npx --yes htmlhint index.html` *(fails: 403 Forbidden - GET https://registry.npmjs.org/htmlhint)*
- `npx --yes stylelint styles.css` *(fails: 403 Forbidden - GET https://registry.npmjs.org/stylelint)*

------
https://chatgpt.com/codex/tasks/task_e_68b84c0be628832fb0384a12ce78175f