### PR TITLE
Remove fuzzy lookup tab and CSV export

### DIFF
--- a/index.html
+++ b/index.html
@@ -77,20 +77,10 @@
           role="tab"
           tabindex="-1"
           aria-selected="false"
-          aria-controls="panel-part-lookup-fuzzy"
-          id="tab-part-lookup-fuzzy"
-        >
-          Part Lookup (Fuzzy)
-        </div>
-        <div
-          class="tab"
-          role="tab"
-          tabindex="-1"
-          aria-selected="false"
           aria-controls="panel-part-lookup-fuzzy-bom"
           id="tab-part-lookup-fuzzy-bom"
         >
-          Part Lookup (Fuzzy BOM)
+          Fuzzy Part Lookup
         </div>
         <div
           class="tab"
@@ -331,28 +321,7 @@
         </div>
         <div id="partLookupResults"></div>
       </section>
-      <!-- Part Lookup Fuzzy -->
-      <section
-        id="panel-part-lookup-fuzzy"
-        class="tab-panel"
-        role="tabpanel"
-        aria-labelledby="tab-part-lookup-fuzzy"
-        tabindex="0"
-      >
-        <div class="topbar">
-          <button id="fuzzyExport">Export results (CSV)</button>
-        </div>
-        <div class="searchbar">
-          <input
-            id="fuzzyQuery"
-            placeholder="Search part number, dash size, thread type, or description…"
-            autocomplete="off"
-          />
-        </div>
-        <div id="fuzzyStats" class="meta"></div>
-        <div id="fuzzyResults" class="results"></div>
-      </section>
-      <!-- Part Lookup Fuzzy BOM -->
+      <!-- Fuzzy Part Lookup -->
       <section
         id="panel-part-lookup-fuzzy-bom"
         class="tab-panel"
@@ -361,7 +330,6 @@
         tabindex="0"
       >
         <div class="topbar" style="display: none;">
-          <button id="fuzzyBomExport">Export results (CSV)</button>
           <button id="fuzzyBomClear">Clear BOM</button>
         </div>
         <div id="fuzzyBomList" class="bom"></div>

--- a/script.js
+++ b/script.js
@@ -585,11 +585,6 @@
   triggerOnEnter(['plPart','plDesc'], 'lookupPart');
 
   // ----- Fuzzy Part Lookup -----
-  const fuzzyInput = document.getElementById('fuzzyQuery');
-  const fuzzyResultsEl = document.getElementById('fuzzyResults');
-  const fuzzyStatsEl = document.getElementById('fuzzyStats');
-  const fuzzyExportBtn = document.getElementById('fuzzyExport');
-  let fuzzyLast = [];
   const fuzzyBomInput = document.getElementById('fuzzyBomQuery');
   const fuzzyBomResultsEl = document.getElementById('fuzzyBomResults');
   const fuzzyBomStatsEl = document.getElementById('fuzzyBomStats');
@@ -597,7 +592,6 @@
   const fuzzyBomTopbarEl = document.querySelector(
     '#panel-part-lookup-fuzzy-bom .topbar'
   );
-  const fuzzyBomExportBtn = document.getElementById('fuzzyBomExport');
   const fuzzyBomClearBtn = document.getElementById('fuzzyBomClear');
   let fuzzyBomLast = [];
   let fuzzyBom = [];
@@ -687,23 +681,6 @@
     return scored.slice(0, limit);
   }
 
-  function renderFuzzy(results, q) {
-    fuzzyResultsEl.innerHTML = '';
-    fuzzyStatsEl.textContent = results.length
-      ? `Top ${results.length} results for "${q}"`
-      : (q ? 'No results.' : '');
-    for (const [s, row] of results) {
-      const div = document.createElement('div');
-      div.className = 'row';
-      const safeDesc = (row.description || '').replace(/</g, '&lt;');
-      div.innerHTML =
-        `<div><strong>${row.part_number || '(no PN)'}</strong> ` +
-        `<span class="score">score ${s.toFixed(2)}</span></div>` +
-        `<div class="meta">${safeDesc}</div>`;
-      fuzzyResultsEl.appendChild(div);
-    }
-  }
-
   function renderBom() {
     if (!fuzzyBomListEl || !fuzzyBomTopbarEl) return;
     fuzzyBomListEl.innerHTML = '';
@@ -745,15 +722,6 @@
 
   renderBom();
 
-  if (fuzzyInput) {
-    fuzzyInput.addEventListener('input', () => {
-      loadItems().then(() => {
-        fuzzyLast = fuzzySearch(fuzzyInput.value, 200);
-        renderFuzzy(fuzzyLast, fuzzyInput.value);
-      });
-    });
-  }
-
   if (fuzzyBomInput) {
     fuzzyBomInput.addEventListener('input', () => {
       loadItems().then(() => {
@@ -762,57 +730,6 @@
       });
     });
   }
-
-  if (fuzzyExportBtn) {
-    fuzzyExportBtn.addEventListener('click', () => {
-      const rows = fuzzyLast.map(([s, r]) => ({
-        score: s.toFixed(3),
-        pn: r.part_number,
-        desc: r.description
-      }));
-      const header = 'score,pn,desc\n';
-      const body = rows
-        .map(r => `${r.score},"${(r.pn || '').replace(/"/g,'""')}","` +
-          `${(r.desc || '').replace(/"/g,'""')}"`)
-        .join('\n');
-      const blob = new Blob(
-        [header + body],
-        {type:'text/csv;charset=utf-8;'}
-      );
-      const url = URL.createObjectURL(blob);
-      const a = document.createElement('a');
-      a.href = url;
-      a.download = 'search_results.csv';
-      a.click();
-      URL.revokeObjectURL(url);
-    });
-  }
-
-  if (fuzzyBomExportBtn) {
-    fuzzyBomExportBtn.addEventListener('click', () => {
-      const rows = fuzzyBomLast.map(([s, r]) => ({
-        score: s.toFixed(3),
-        pn: r.part_number,
-        desc: r.description
-      }));
-      const header = 'score,pn,desc\n';
-      const body = rows
-        .map(r => `${r.score},"${(r.pn || '').replace(/"/g,'""')}","` +
-          `${(r.desc || '').replace(/"/g,'""')}"`)
-        .join('\n');
-      const blob = new Blob(
-        [header + body],
-        {type:'text/csv;charset=utf-8;'}
-      );
-      const url = URL.createObjectURL(blob);
-      const a = document.createElement('a');
-      a.href = url;
-      a.download = 'search_results.csv';
-      a.click();
-      URL.revokeObjectURL(url);
-    });
-  }
-
   if (fuzzyBomClearBtn) {
     fuzzyBomClearBtn.addEventListener('click', () => {
       fuzzyBom = [];

--- a/styles.css
+++ b/styles.css
@@ -71,7 +71,6 @@ h3 {
 }
 
 /* Fuzzy part lookup styles */
-#panel-part-lookup-fuzzy .topbar,
 #panel-part-lookup-fuzzy-bom .topbar {
   display: flex;
   gap: 10px;
@@ -79,30 +78,25 @@ h3 {
   flex-wrap: wrap;
   margin-top: 8px;
 }
-#panel-part-lookup-fuzzy .hint,
 #panel-part-lookup-fuzzy-bom .hint {
   font-size: 0.875rem;
   color: #555;
 }
-#panel-part-lookup-fuzzy .searchbar,
 #panel-part-lookup-fuzzy-bom .searchbar {
   display: flex;
   gap: 12px;
   align-items: center;
   margin-top: 10px;
 }
-#panel-part-lookup-fuzzy .searchbar input,
 #panel-part-lookup-fuzzy-bom .searchbar input {
   flex: 1;
   padding: 12px 14px;
   border: 1px solid #d1d9e6;
   border-radius: 6px;
 }
-#panel-part-lookup-fuzzy .results,
 #panel-part-lookup-fuzzy-bom .results {
   margin-top: 14px;
 }
-#panel-part-lookup-fuzzy .row,
 #panel-part-lookup-fuzzy-bom .row {
   background: #f9f9f9;
   border: 1px solid #d1d9e6;
@@ -110,19 +104,16 @@ h3 {
   padding: 10px 12px;
   margin: 10px 0;
 }
-#panel-part-lookup-fuzzy .meta,
 #panel-part-lookup-fuzzy-bom .meta {
   font-size: 0.875rem;
   color: #555;
   margin-top: 4px;
 }
-#panel-part-lookup-fuzzy .score,
 #panel-part-lookup-fuzzy-bom .score {
   font-variant-numeric: tabular-nums;
   color: #888;
   font-size: 0.75rem;
 }
-#panel-part-lookup-fuzzy button,
 #panel-part-lookup-fuzzy-bom button {
   padding: 6px 10px;
   font-size: 0.875rem;


### PR DESCRIPTION
## Summary
- drop unused "Part Lookup (Fuzzy)" tab and its CSV export
- rename fuzzy BOM tab to "Fuzzy Part Lookup"
- clean up JavaScript and CSS after removing export feature

## Testing
- `npx --yes htmlhint index.html` *(fails: 403 Forbidden)*
- `npx --yes stylelint styles.css` *(fails: 403 Forbidden)*
- `tidy -errors -q index.html` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b84dcd7ba4832f8dead165f4ed82b5