### PR TITLE
Hide empty BOM list until populated

### DIFF
--- a/index.html
+++ b/index.html
@@ -332,7 +332,7 @@
         <div class="topbar" style="display: none;">
           <button id="fuzzyBomClear">Clear BOM</button>
         </div>
-        <div id="fuzzyBomList" class="bom"></div>
+        <div id="fuzzyBomList" class="bom" style="display: none;"></div>
         <div class="searchbar">
           <input
             id="fuzzyBomQuery"

--- a/script.js
+++ b/script.js
@@ -691,7 +691,9 @@
         `<span class="meta">${safe}</span>`;
       fuzzyBomListEl.appendChild(div);
     }
-    fuzzyBomTopbarEl.style.display = fuzzyBom.length ? 'flex' : 'none';
+    const show = fuzzyBom.length > 0;
+    fuzzyBomTopbarEl.style.display = show ? 'flex' : 'none';
+    fuzzyBomListEl.style.display = show ? 'block' : 'none';
     localStorage.setItem('fuzzyBom', JSON.stringify(fuzzyBom));
   }
 


### PR DESCRIPTION
## Summary
- Hide Fuzzy BOM box until it has items and show it when populated
- Keep "Clear BOM" toolbar synced with list visibility

## Testing
- `npx htmlhint index.html` *(fails: 403 Forbidden - GET https://registry.npmjs.org/htmlhint)*
- `npx stylelint styles.css` *(fails: 403 Forbidden - GET https://registry.npmjs.org/stylelint)*

------
https://chatgpt.com/codex/tasks/task_e_68b851829220832fbadd8cc8011d7a1d