### PR TITLE
Display fuzzy BOM as table

### DIFF
--- a/script.js
+++ b/script.js
@@ -684,12 +684,22 @@
   function renderBom() {
     if (!fuzzyBomListEl || !fuzzyBomTopbarEl) return;
     fuzzyBomListEl.innerHTML = '';
-    for (const item of fuzzyBom) {
-      const div = document.createElement('div');
-      const safe = (item.desc || '').replace(/</g, '&lt;');
-      div.innerHTML = `<strong>${item.pn || ''}</strong> ` +
-        `<span class="meta">${safe}</span>`;
-      fuzzyBomListEl.appendChild(div);
+    if (fuzzyBom.length) {
+      const table = document.createElement('table');
+      const thead = document.createElement('thead');
+      thead.innerHTML =
+        '<tr><th>Part Number</th><th>Description</th></tr>';
+      table.appendChild(thead);
+      const tbody = document.createElement('tbody');
+      for (const item of fuzzyBom) {
+        const tr = document.createElement('tr');
+        const safe = (item.desc || '').replace(/</g, '&lt;');
+        tr.innerHTML = `<td>${item.pn || ''}</td>` +
+          `<td>${safe}</td>`;
+        tbody.appendChild(tr);
+      }
+      table.appendChild(tbody);
+      fuzzyBomListEl.appendChild(table);
     }
     const show = fuzzyBom.length > 0;
     fuzzyBomTopbarEl.style.display = show ? 'flex' : 'none';

--- a/styles.css
+++ b/styles.css
@@ -121,10 +121,25 @@ h3 {
 
 #panel-part-lookup-fuzzy-bom .bom {
   margin-top: 10px;
-  padding: 10px 12px;
+  overflow-x: auto;
+}
+
+#panel-part-lookup-fuzzy-bom .bom table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+#panel-part-lookup-fuzzy-bom .bom th,
+#panel-part-lookup-fuzzy-bom .bom td {
   border: 1px solid #d1d9e6;
-  border-radius: 6px;
-  background: #f9f9f9;
+  padding: 6px 8px;
+  text-align: left;
+}
+
+#panel-part-lookup-fuzzy-bom .bom th {
+  background: #2980b9;
+  color: #fff;
+  font-weight: 600;
 }
 
 /* --- Calculator common styles --- */


### PR DESCRIPTION
## Summary
- Render fuzzy BOM list as a table with part number and description columns
- Style BOM table to resemble a spreadsheet grid

## Testing
- `npx htmlhint index.html spudnik_part_lookup_singlefile.html` *(fails: 403 Forbidden - GET https://registry.npmjs.org/htmlhint)*
- `npx stylelint styles.css` *(fails: 403 Forbidden - GET https://registry.npmjs.org/stylelint)*
- `npm test` *(fails: ENOENT: no such file or directory, open '/workspace/fluidpowertools/package.json')*

------
https://chatgpt.com/codex/tasks/task_e_68b87c284388832f9659d6654d9db1e2