### PR TITLE
Enable multi-cell selection in fuzzy BOM

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -156,17 +156,8 @@ h3 {
   padding: 2px 4px;
 }
 
-#panel-part-lookup-fuzzy-bom .bom .selected-col {
-  background: #dfe6e9;
-}
-
 #panel-part-lookup-fuzzy-bom .bom .selected-cell {
   background: #a3d5ff;
-}
-
-#panel-part-lookup-fuzzy-bom .bom .selected-row > th,
-#panel-part-lookup-fuzzy-bom .bom .selected-row > td {
-  background: #ffeaa7;
 }
 
 /* --- Calculator common styles --- */


### PR DESCRIPTION
## Summary
- Allow selecting rectangular ranges within the fuzzy BOM table
- Store selection range and support copying multi-cell grids to the clipboard
- Simplify BOM styles to use a single `selected-cell` highlight

## Testing
- `node --check script.js`
- `npx stylelint styles.css` *(fails: 403 Forbidden)*
- `npm test` *(fails: package.json not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b9c24a2a70832f89876a00640493a5