### PR TITLE
Add sortable tables and row removal for fuzzy BOM

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -160,6 +160,37 @@ h3 {
   background: #a3d5ff;
 }
 
+#panel-part-lookup-fuzzy-bom .results table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+#panel-part-lookup-fuzzy-bom .results th,
+#panel-part-lookup-fuzzy-bom .results td {
+  border: 1px solid #d1d9e6;
+  padding: 6px 8px;
+  text-align: left;
+}
+
+#panel-part-lookup-fuzzy-bom .results th {
+  background: #2980b9;
+  color: #fff;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+#panel-part-lookup-fuzzy-bom .bom button.remove {
+  background: #e74c3c;
+  color: #fff;
+  border: none;
+  padding: 2px 6px;
+  border-radius: 4px;
+}
+
+#panel-part-lookup-fuzzy-bom .bom button.remove:hover {
+  background: #c0392b;
+}
+
 /* --- Calculator common styles --- */
 label {
   font-weight: 600;


### PR DESCRIPTION
## Summary
- display fuzzy search results in a sortable table
- allow sorting and row removal within the BOM table
- style tables and remove buttons for the fuzzy BOM tab

## Testing
- `node --check script.js`
- `npx htmlhint index.html` *(fails: 403 Forbidden - GET https://registry.npmjs.org/htmlhint)*
- `npx stylelint styles.css` *(fails: 403 Forbidden - GET https://registry.npmjs.org/stylelint)*

------
https://chatgpt.com/codex/tasks/task_e_68b9c53342b8832f9891528ce690ddf5