### PR TITLE
Add send-to-BOM comparator option for fuzzy BOM

### DIFF
--- a/index.html
+++ b/index.html
@@ -331,6 +331,8 @@
       >
         <div class="topbar" style="display: none;">
           <button id="fuzzyBomClear">Clear BOM</button>
+          <button id="fuzzySendOld">Send to Old BOM</button>
+          <button id="fuzzySendNew">Send to New BOM</button>
         </div>
         <div id="fuzzyBomList" class="bom" style="display: none;"></div>
         <div class="searchbar">

--- a/script.js
+++ b/script.js
@@ -593,6 +593,8 @@
     '#panel-part-lookup-fuzzy-bom .topbar'
   );
   const fuzzyBomClearBtn = document.getElementById('fuzzyBomClear');
+  const fuzzySendOldBtn = document.getElementById('fuzzySendOld');
+  const fuzzySendNewBtn = document.getElementById('fuzzySendNew');
   let fuzzySelection = null;
   let fuzzyBomLast = [];
   let fuzzyBom = [];
@@ -694,6 +696,20 @@
       c.classList.remove('selected-cell')
     );
     fuzzySelection = null;
+  }
+
+  function sendFuzzyBom(target) {
+    const lines = fuzzyBom
+      .filter(it => it.pn)
+      .map(it => `${it.pn}\t${it.qty}`);
+    const text = lines.join('\n');
+    if (target === 'old') {
+      oldBOMEl.value = text;
+      localStorage.setItem('oldBOM', text);
+    } else if (target === 'new') {
+      newBOMEl.value = text;
+      localStorage.setItem('newBOM', text);
+    }
   }
 
   function renderBom() {
@@ -925,6 +941,16 @@
     fuzzyBomClearBtn.addEventListener('click', () => {
       fuzzyBom = [];
       renderBom();
+    });
+  }
+  if (fuzzySendOldBtn) {
+    fuzzySendOldBtn.addEventListener('click', () => {
+      sendFuzzyBom('old');
+    });
+  }
+  if (fuzzySendNewBtn) {
+    fuzzySendNewBtn.addEventListener('click', () => {
+      sendFuzzyBom('new');
     });
   }
 


### PR DESCRIPTION
## Summary
- add buttons to export fuzzy BOM items to old or new BOM comparator fields
- implement helper to format part numbers and quantities before transfer

## Testing
- `npx htmlhint index.html` *(fails: 403 Forbidden)*
- `npx stylelint styles.css` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68b9dfc23cf4832fa7e00c0ea9fb82ab