### PR TITLE
Fix quantity spinner in fuzzy BOM

### DIFF
--- a/script.js
+++ b/script.js
@@ -809,6 +809,7 @@
       }
 
       table.addEventListener('mousedown', e => {
+        if (e.target.tagName === 'INPUT') return;
         const cell = e.target.closest('td');
         if (!cell) return;
         isSel = true;


### PR DESCRIPTION
## Summary
- Allow quantity spinners in fuzzy BOM to function by bypassing selection logic when clicking inputs

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68ba0783c1f4832fbe9c7fd55469aee7