### PR TITLE
Group calculators under single tab with nested sub-tabs

### DIFF
--- a/index.html
+++ b/index.html
@@ -17,40 +17,10 @@
           role="tab"
           tabindex="0"
           aria-selected="true"
-          aria-controls="panel-pressure-drop"
-          id="tab-pressure-drop"
+          aria-controls="panel-calculators"
+          id="tab-calculators"
         >
-          Pressure Drop
-        </div>
-        <div
-          class="tab"
-          role="tab"
-          tabindex="-1"
-          aria-selected="false"
-          aria-controls="panel-unit-conversions"
-          id="tab-unit-conversions"
-        >
-          Unit Conversions
-        </div>
-        <div
-          class="tab"
-          role="tab"
-          tabindex="-1"
-          aria-selected="false"
-          aria-controls="panel-cylinder-force"
-          id="tab-cylinder-force"
-        >
-          Cylinder Force
-        </div>
-        <div
-          class="tab"
-          role="tab"
-          tabindex="-1"
-          aria-selected="false"
-          aria-controls="panel-pump-power"
-          id="tab-pump-power"
-        >
-          Pump Power
+          Calculators
         </div>
         <div
           class="tab"
@@ -94,122 +64,180 @@
         </div>
       </div>
 
-      <!-- Pressure Drop -->
+      <!-- Calculators -->
       <section
-        id="panel-pressure-drop"
+        id="panel-calculators"
         class="tab-panel active"
         role="tabpanel"
-        aria-labelledby="tab-pressure-drop"
+        aria-labelledby="tab-calculators"
         tabindex="0"
       >
-        <label class="calc-label" for="pdFlow">Flow Rate (GPM):</label>
-        <input type="number" id="pdFlow" min="0" step="any" />
+        <div class="sub-tabs" role="tablist" aria-label="Calculators">
+          <div
+            class="sub-tab active"
+            role="tab"
+            tabindex="0"
+            aria-selected="true"
+            aria-controls="sub-panel-pressure-drop"
+            id="sub-tab-pressure-drop"
+          >
+            Pressure Drop
+          </div>
+          <div
+            class="sub-tab"
+            role="tab"
+            tabindex="-1"
+            aria-selected="false"
+            aria-controls="sub-panel-unit-conversions"
+            id="sub-tab-unit-conversions"
+          >
+            Unit Conversions
+          </div>
+          <div
+            class="sub-tab"
+            role="tab"
+            tabindex="-1"
+            aria-selected="false"
+            aria-controls="sub-panel-cylinder-force"
+            id="sub-tab-cylinder-force"
+          >
+            Cylinder Force
+          </div>
+          <div
+            class="sub-tab"
+            role="tab"
+            tabindex="-1"
+            aria-selected="false"
+            aria-controls="sub-panel-pump-power"
+            id="sub-tab-pump-power"
+          >
+            Pump Power
+          </div>
+        </div>
 
-        <label class="calc-label" for="pdDiameter"
-          >Pipe/Hose Diameter (inches):</label
+        <!-- Pressure Drop -->
+        <section
+          id="sub-panel-pressure-drop"
+          class="sub-panel active"
+          role="tabpanel"
+          aria-labelledby="sub-tab-pressure-drop"
+          tabindex="0"
         >
-        <input type="number" id="pdDiameter" min="0" step="any" />
+          <label class="calc-label" for="pdFlow">Flow Rate (GPM):</label>
+          <input type="number" id="pdFlow" min="0" step="any" />
 
-        <label class="calc-label" for="pdLength">Length (feet):</label>
-        <input type="number" id="pdLength" min="0" step="any" />
+          <label class="calc-label" for="pdDiameter"
+            >Pipe/Hose Diameter (inches):</label
+          >
+          <input type="number" id="pdDiameter" min="0" step="any" />
 
-        <label class="calc-label" for="pdViscosity"
-          >Dynamic Viscosity (cP):</label
+          <label class="calc-label" for="pdLength">Length (feet):</label>
+          <input type="number" id="pdLength" min="0" step="any" />
+
+          <label class="calc-label" for="pdViscosity"
+            >Dynamic Viscosity (cP):</label
+          >
+          <input
+            type="number"
+            id="pdViscosity"
+            min="0"
+            step="any"
+            value="40"
+          />
+
+          <div class="button-row">
+            <button id="calcPressureDrop">Calculate Pressure Drop (psi)</button>
+            <button id="clearPressureDrop">Clear</button>
+          </div>
+          <div id="pressureDropResult"></div>
+        </section>
+
+        <!-- Unit Conversions -->
+        <section
+          id="sub-panel-unit-conversions"
+          class="sub-panel"
+          role="tabpanel"
+          aria-labelledby="sub-tab-unit-conversions"
+          tabindex="0"
         >
-        <input type="number" id="pdViscosity" min="0" step="any" value="40" />
+          <label class="calc-label" for="ucCategory">Conversion Type:</label>
+          <select id="ucCategory">
+            <option value="flow">Flow</option>
+            <option value="pressure">Pressure</option>
+            <option value="force">Force</option>
+            <option value="power">Power</option>
+            <option value="length">Length</option>
+          </select>
 
-        <div class="button-row">
-          <button id="calcPressureDrop">Calculate Pressure Drop (psi)</button>
-          <button id="clearPressureDrop">Clear</button>
-        </div>
-        <div id="pressureDropResult"></div>
-      </section>
+          <label class="calc-label" for="ucValue">Value:</label>
+          <input type="number" id="ucValue" min="0" step="any" />
 
-      <!-- Unit Conversions -->
-      <section
-        id="panel-unit-conversions"
-        class="tab-panel"
-        role="tabpanel"
-        aria-labelledby="tab-unit-conversions"
-        tabindex="0"
-      >
-        <label class="calc-label" for="ucCategory">Conversion Type:</label>
-        <select id="ucCategory">
-          <option value="flow">Flow</option>
-          <option value="pressure">Pressure</option>
-          <option value="force">Force</option>
-          <option value="power">Power</option>
-          <option value="length">Length</option>
-        </select>
+          <label class="calc-label" for="ucFromUnit">From Unit:</label>
+          <select id="ucFromUnit"></select>
 
-        <label class="calc-label" for="ucValue">Value:</label>
-        <input type="number" id="ucValue" min="0" step="any" />
+          <label class="calc-label" for="ucToUnit">To Unit:</label>
+          <select id="ucToUnit"></select>
 
-        <label class="calc-label" for="ucFromUnit">From Unit:</label>
-        <select id="ucFromUnit"></select>
+          <div class="button-row">
+            <button id="convertUnitBtn">Convert</button>
+            <button id="clearUnitConvert">Clear</button>
+          </div>
+          <div id="unitConvertResult"></div>
+        </section>
 
-        <label class="calc-label" for="ucToUnit">To Unit:</label>
-        <select id="ucToUnit"></select>
-
-        <div class="button-row">
-          <button id="convertUnitBtn">Convert</button>
-          <button id="clearUnitConvert">Clear</button>
-        </div>
-        <div id="unitConvertResult"></div>
-      </section>
-
-      <!-- Cylinder Force -->
-      <section
-        id="panel-cylinder-force"
-        class="tab-panel"
-        role="tabpanel"
-        aria-labelledby="tab-cylinder-force"
-        tabindex="0"
-      >
-        <label class="calc-label" for="cylBoreDiameter"
-          >Cylinder Bore Diameter (inches):</label
+        <!-- Cylinder Force -->
+        <section
+          id="sub-panel-cylinder-force"
+          class="sub-panel"
+          role="tabpanel"
+          aria-labelledby="sub-tab-cylinder-force"
+          tabindex="0"
         >
-        <input type="number" id="cylBoreDiameter" min="0" step="any" />
+          <label class="calc-label" for="cylBoreDiameter"
+            >Cylinder Bore Diameter (inches):</label
+          >
+          <input type="number" id="cylBoreDiameter" min="0" step="any" />
 
-        <label class="calc-label" for="cylPressure">Pressure (psi):</label>
-        <input type="number" id="cylPressure" min="0" step="any" />
+          <label class="calc-label" for="cylPressure">Pressure (psi):</label>
+          <input type="number" id="cylPressure" min="0" step="any" />
 
-        <div class="button-row">
-          <button id="calcCylinderForceBtn">Calculate Force (lbf)</button>
-          <button id="clearCylinderForce">Clear</button>
-        </div>
-        <div id="cylinderForceResult"></div>
-      </section>
+          <div class="button-row">
+            <button id="calcCylinderForceBtn">Calculate Force (lbf)</button>
+            <button id="clearCylinderForce">Clear</button>
+          </div>
+          <div id="cylinderForceResult"></div>
+        </section>
 
-      <!-- Pump Power -->
-      <section
-        id="panel-pump-power"
-        class="tab-panel"
-        role="tabpanel"
-        aria-labelledby="tab-pump-power"
-        tabindex="0"
-      >
-        <label class="calc-label" for="pumpFlow">Flow Rate (GPM):</label>
-        <input type="number" id="pumpFlow" min="0" step="any" />
+        <!-- Pump Power -->
+        <section
+          id="sub-panel-pump-power"
+          class="sub-panel"
+          role="tabpanel"
+          aria-labelledby="sub-tab-pump-power"
+          tabindex="0"
+        >
+          <label class="calc-label" for="pumpFlow">Flow Rate (GPM):</label>
+          <input type="number" id="pumpFlow" min="0" step="any" />
 
-        <label class="calc-label" for="pumpPressure">Pressure (psi):</label>
-        <input type="number" id="pumpPressure" min="0" step="any" />
+          <label class="calc-label" for="pumpPressure">Pressure (psi):</label>
+          <input type="number" id="pumpPressure" min="0" step="any" />
 
-        <label class="calc-label" for="pumpEfficiency">Efficiency (%):</label>
-        <input
-          type="number"
-          id="pumpEfficiency"
-          min="1"
-          max="100"
-          step="any"
-          value="85"
-        />
+          <label class="calc-label" for="pumpEfficiency">Efficiency (%):</label>
+          <input
+            type="number"
+            id="pumpEfficiency"
+            min="1"
+            max="100"
+            step="any"
+            value="85"
+          />
 
-        <div class="button-row">
-          <button id="calcPumpPowerBtn">Calculate Power (HP)</button>
-          <button id="clearPumpPower">Clear</button>
-        </div>
-        <div id="pumpPowerResult"></div>
+          <div class="button-row">
+            <button id="calcPumpPowerBtn">Calculate Power (HP)</button>
+            <button id="clearPumpPower">Clear</button>
+          </div>
+          <div id="pumpPowerResult"></div>
+        </section>
       </section>
 
       <!-- BOM Comparator -->

--- a/script.js
+++ b/script.js
@@ -68,6 +68,57 @@
     activateTab(0);
   }
 
+  // Sub-tab switching logic for calculators
+  const calcContainer = document.getElementById('panel-calculators');
+  if (calcContainer) {
+    const calcTabs = calcContainer.querySelectorAll('.sub-tab');
+    const calcPanels = calcContainer.querySelectorAll('.sub-panel');
+    calcTabs.forEach((tab, i) => {
+      tab.addEventListener('click', () => {
+        activateCalcTab(i);
+      });
+      tab.addEventListener('keydown', e => {
+        if (e.key === 'ArrowRight' || e.key === 'ArrowLeft') {
+          e.preventDefault();
+          let ni = i;
+          if (e.key === 'ArrowRight') {
+            ni = (i + 1) % calcTabs.length;
+          } else {
+            ni = (i - 1 + calcTabs.length) % calcTabs.length;
+          }
+          activateCalcTab(ni);
+          calcTabs[ni].focus();
+        }
+      });
+    });
+
+    function activateCalcTab(index) {
+      calcTabs.forEach((tab, i) => {
+        if (i === index) {
+          tab.classList.add('active');
+          tab.setAttribute('aria-selected', 'true');
+          tab.setAttribute('tabindex', '0');
+          calcPanels[i].classList.add('active');
+        } else {
+          tab.classList.remove('active');
+          tab.setAttribute('aria-selected', 'false');
+          tab.setAttribute('tabindex', '-1');
+          calcPanels[i].classList.remove('active');
+        }
+      });
+      localStorage.setItem('activeCalcTab', index);
+    }
+
+    const storedCalc = localStorage.getItem('activeCalcTab');
+    const calcIndex =
+      storedCalc !== null ? parseInt(storedCalc, 10) : 0;
+    if (calcIndex >= 0 && calcIndex < calcTabs.length) {
+      activateCalcTab(calcIndex);
+    } else {
+      activateCalcTab(0);
+    }
+  }
+
   const persistEls = document.querySelectorAll('input, select, textarea');
   persistEls.forEach(el => {
     if (!el.id) return;

--- a/styles.css
+++ b/styles.css
@@ -70,6 +70,43 @@ h3 {
   display: block;
 }
 
+/* Sub-tabs */
+.sub-tabs {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin-bottom: 20px;
+  user-select: none;
+  justify-content: center;
+}
+.sub-tab {
+  flex: 1 1 150px;
+  background: #2980b9;
+  color: white;
+  padding: 8px 8px;
+  text-align: center;
+  font-weight: 600;
+  border-radius: 6px;
+  cursor: pointer;
+  transition: background 0.3s ease;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+.sub-tab:hover {
+  background: #1f618d;
+}
+.sub-tab.active {
+  background: #ff1a1a;
+  cursor: default;
+}
+.sub-panel {
+  display: none;
+}
+.sub-panel.active {
+  display: block;
+}
+
 /* Fuzzy part lookup styles */
 #panel-part-lookup-fuzzy-bom .topbar {
   display: flex;
@@ -436,6 +473,16 @@ th.sort-desc::after {
   }
 
   .tab {
+    flex: 1 1 45%;
+    justify-content: center;
+    font-size: 0.95rem;
+  }
+
+  .sub-tabs {
+    flex-wrap: wrap;
+  }
+
+  .sub-tab {
     flex: 1 1 45%;
     justify-content: center;
     font-size: 0.95rem;


### PR DESCRIPTION
## Summary
- Combine individual calculator pages into a unified **Calculators** tab.
- Add nested sub-tabs for Pressure Drop, Unit Conversions, Cylinder Force, and Pump Power.
- Implement sub-tab switching logic and responsive styles.

## Testing
- `npx html-validate index.html` *(fails: 403 Forbidden)*
- `tidy -errors -q index.html` *(fails: command not found)*
- `npx stylelint styles.css` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68ba0cc82b94832faef59e1dd88df2aa