### PR TITLE
Add prefix-based filter to fuzzy BOM

### DIFF
--- a/index.html
+++ b/index.html
@@ -364,6 +364,14 @@
         </div>
         <div id="fuzzyBomList" class="bom" style="display: none;"></div>
         <div class="searchbar">
+          <select id="fuzzyBomFilter">
+            <option value="">All Parts</option>
+            <option value="60">60 - Hydraulic Parts</option>
+            <option value="30">30 - Labels/Stickers</option>
+            <option value="73">73 - Pipe</option>
+            <option value="HA">HA - Hydraulic Assemblies</option>
+            <option value="HK">HK - Hose Kits</option>
+          </select>
           <input
             id="fuzzyBomQuery"
             placeholder="Search part number, dash size, thread type, or description…"

--- a/script.js
+++ b/script.js
@@ -643,6 +643,7 @@
   const fuzzyBomTopbarEl = document.querySelector(
     '#panel-part-lookup-fuzzy-bom .topbar'
   );
+  const fuzzyBomFilterEl = document.getElementById('fuzzyBomFilter');
   const fuzzyBomClearBtn = document.getElementById('fuzzyBomClear');
   const fuzzySendOldBtn = document.getElementById('fuzzySendOld');
   const fuzzySendNewBtn = document.getElementById('fuzzySendNew');
@@ -727,8 +728,15 @@
     const nq = normalize(q);
     const tokens = nq.split(' ').filter(Boolean);
     if (tokens.length === 0) return [];
+    const filter = (fuzzyBomFilterEl && fuzzyBomFilterEl.value) || '';
     const scored = [];
     for (const row of itemsData || []) {
+      if (filter) {
+        const prefix = (row.part_number || '')
+          .toUpperCase()
+          .slice(0, 2);
+        if (prefix !== filter) continue;
+      }
       const s = scoreRow(
         tokens,
         row.description || '',
@@ -988,13 +996,17 @@
 
   renderBom();
 
-  if (fuzzyBomInput) {
-    fuzzyBomInput.addEventListener('input', () => {
-      loadItems().then(() => {
-        fuzzyBomLast = fuzzySearch(fuzzyBomInput.value, 200);
-        renderFuzzyBom(fuzzyBomLast, fuzzyBomInput.value);
-      });
+  function updateFuzzySearch() {
+    loadItems().then(() => {
+      fuzzyBomLast = fuzzySearch(fuzzyBomInput.value, 200);
+      renderFuzzyBom(fuzzyBomLast, fuzzyBomInput.value);
     });
+  }
+  if (fuzzyBomInput) {
+    fuzzyBomInput.addEventListener('input', updateFuzzySearch);
+  }
+  if (fuzzyBomFilterEl) {
+    fuzzyBomFilterEl.addEventListener('change', updateFuzzySearch);
   }
   if (fuzzyBomClearBtn) {
     fuzzyBomClearBtn.addEventListener('click', () => {

--- a/styles.css
+++ b/styles.css
@@ -131,6 +131,11 @@ h3 {
   border: 1px solid #d1d9e6;
   border-radius: 6px;
 }
+#panel-part-lookup-fuzzy-bom .searchbar select {
+  padding: 12px 14px;
+  border: 1px solid #d1d9e6;
+  border-radius: 6px;
+}
 #panel-part-lookup-fuzzy-bom .results {
   margin-top: 14px;
 }


### PR DESCRIPTION
## Summary
- add dropdown to fuzzy BOM allowing users to filter items by part number prefix categories
- extend search logic to honor selected prefix and update results live

## Testing
- `npm test` *(fails: Missing script "test")*
- `npx htmlhint index.html styles.css` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68beed8058a4832fafd5168dfc1ff8c4