### PR TITLE
style: shrink fuzzy BOM filter

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -123,7 +123,7 @@ h3 {
   display: flex;
   flex-direction: column;
   align-items: flex-start;
-  gap: 8px;
+  gap: 6px;
   margin-top: 10px;
 }
 #panel-part-lookup-fuzzy-bom .searchbar input {
@@ -133,8 +133,9 @@ h3 {
   border-radius: 6px;
 }
 #panel-part-lookup-fuzzy-bom .searchbar select {
-  width: 200px;
-  padding: 8px 10px;
+  width: 160px;
+  padding: 6px 8px;
+  font-size: 14px;
   border: 1px solid #d1d9e6;
   border-radius: 6px;
 }


### PR DESCRIPTION
## Summary
- Reduce vertical gap and width for fuzzy BOM filter dropdown
- Slightly decrease padding and font size for a more compact filter

## Testing
- `npx --yes htmlhint index.html` *(fails: 403 Forbidden)*
- `npx --yes stylelint styles.css` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68bf17ae25bc832fa8b7a62926c529d9