### PR TITLE
Refine progress tracker UI and substatus progress

### DIFF
--- a/progress-tracker.js
+++ b/progress-tracker.js
@@ -70,6 +70,12 @@
     completed: 1
   };
 
+  const substatusProgress = {
+    modeled: 0.6,
+    quoted: 0.75,
+    drafted: 0.9
+  };
+
   const projSel = document.getElementById('ptProject');
   const filterSel = document.getElementById('ptFilter');
   const treeEl = document.getElementById('ptTree');
@@ -183,7 +189,14 @@
 
   function progress(node) {
     if (!node.children.length) {
-      node.progress = statusProgress[node.status] || 0;
+      if (node.status === 'work_in_progress') {
+        node.progress =
+          substatusProgress[node.substatus] ||
+          statusProgress[node.status] ||
+          0;
+      } else {
+        node.progress = statusProgress[node.status] || 0;
+      }
     } else {
       let sum = 0;
       for (const c of node.children) sum += progress(c);
@@ -264,7 +277,11 @@
     }
     statusSel.addEventListener('change', e => {
       node.status = e.target.value;
-      if (node.status !== 'work_in_progress') node.substatus = null;
+      if (node.status === 'work_in_progress') {
+        node.substatus = node.substatus || 'modeled';
+      } else {
+        node.substatus = null;
+      }
       renderTree();
     });
     row.appendChild(statusSel);
@@ -282,7 +299,7 @@
       node.status === 'work_in_progress' ? '' : 'none';
     subSel.addEventListener('change', e => {
       node.substatus = e.target.value;
-      saveProject();
+      renderTree();
     });
     row.appendChild(subSel);
 

--- a/styles.css
+++ b/styles.css
@@ -528,6 +528,25 @@ th.sort-desc::after {
 }
 #ptControls label {
   font-weight: 600;
+  display: flex;
+  align-items: center;
+  gap: 4px;
+}
+#ptControls button {
+  padding: 4px 8px;
+  font-size: 0.85rem;
+  border: none;
+  border-radius: 4px;
+  background: #2980b9;
+  color: #fff;
+  cursor: pointer;
+}
+#ptControls button:hover {
+  background: #1f618d;
+}
+#ptControls select {
+  padding: 3px 5px;
+  font-size: 0.85rem;
 }
 #ptTree ul {
   list-style: none;
@@ -564,6 +583,10 @@ th.sort-desc::after {
 }
 .pt-mini {
   padding: 4px 8px;
+  font-size: 0.8rem;
+}
+.pt-row select {
+  padding: 2px 4px;
   font-size: 0.8rem;
 }
 .status-not_started {


### PR DESCRIPTION
## Summary
- Style progress tracker controls and dropdowns for a more compact, cohesive look
- Ensure status changes default to a substatus and re-render the tree
- Incorporate substatus stages into progress calculations for work-in-progress items

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68c08ce87c3c832fb91fc6f58b3c2343