### PR TITLE
Improve progress tracker status handling

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -529,7 +529,7 @@ th.sort-desc::after {
 #ptControls label {
   font-weight: 600;
   display: flex;
-  align-items: center;
+  align-items: baseline;
   gap: 4px;
 }
 #ptControls button {
@@ -557,6 +557,9 @@ th.sort-desc::after {
   align-items: center;
   gap: 6px;
   padding: 2px 0;
+}
+.pt-id {
+  width: 80px;
 }
 .pt-desc {
   flex: 1;


### PR DESCRIPTION
## Summary
- Add blank substatus option and map modeled/quoted progress to 33% and 66%
- Promote drafted substatus to completed and derive parent status from children
- Show item numbers in tree and align project/filter dropdowns with their labels

## Testing
- `npm test`
- `npx htmlhint index.html` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68c0933f6168832fb6511088f15e6a91