### PR TITLE
Improve progress tracker layout and parent substatus handling

### DIFF
--- a/progress-tracker.js
+++ b/progress-tracker.js
@@ -225,7 +225,7 @@
         : notStarted
         ? 'not_started'
         : 'work_in_progress';
-      node.substatus = null;
+      if (node.status !== 'work_in_progress') node.substatus = null;
     }
     const item = items.find(it => it.id === node.id);
     if (item) {
@@ -339,7 +339,7 @@
     subSel.addEventListener('change', e => {
       const item = items.find(it => it.id === node.id);
       if (item) {
-        if (e.target.value === 'drafted') {
+        if (e.target.value === 'drafted' && !node.children.length) {
           item.status = 'completed';
           item.substatus = null;
         } else {

--- a/styles.css
+++ b/styles.css
@@ -523,7 +523,7 @@ th.sort-desc::after {
   display: flex;
   flex-wrap: wrap;
   gap: 10px;
-  align-items: center;
+  align-items: flex-end;
   margin-bottom: 15px;
 }
 #ptControls label {
@@ -548,15 +548,20 @@ th.sort-desc::after {
   padding: 3px 5px;
   font-size: 0.85rem;
 }
+#ptTree {
+  overflow-x: auto;
+}
 #ptTree ul {
   list-style: none;
   padding-left: 20px;
 }
 .pt-row {
-  display: flex;
+  display: grid;
+  grid-template-columns: 1em 80px 1fr 50px 110px 110px auto auto auto;
   align-items: center;
   gap: 6px;
   padding: 2px 0;
+  min-width: 700px;
 }
 .pt-id {
   width: 80px;
@@ -589,6 +594,7 @@ th.sort-desc::after {
   font-size: 0.8rem;
 }
 .pt-row select {
+  width: 100%;
   padding: 2px 4px;
   font-size: 0.8rem;
 }


### PR DESCRIPTION
## Summary
- refine progress tracker row layout with CSS grid and scroll to prevent overlap
- align project buttons with dropdowns
- allow manual substatus updates on parent items

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68c095d32cd4832fb6f3863f145c5499