### PR TITLE
Move progress tracker to standalone page

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,7 +10,9 @@
   <body>
     <div id="container" role="main" aria-label="Fluid power tools">
       <h3>Fluid Power Tools</h3>
-
+      <p id="ptLink">
+        <a href="progress-tracker.html">Progress Tracker</a>
+      </p>
       <div class="tabs" role="tablist" aria-label="Tool categories">
         <div
           class="tab active"
@@ -61,16 +63,6 @@
           id="tab-reference"
         >
           Reference
-        </div>
-        <div
-          class="tab"
-          role="tab"
-          tabindex="-1"
-          aria-selected="false"
-          aria-controls="panel-progress-tracker"
-          id="tab-progress-tracker"
-        >
-          Progress Tracker
         </div>
       </div>
 
@@ -487,49 +479,8 @@
           </tbody>
         </table>
       </section>
-      <!-- Progress Tracker -->
-      <section
-        id="panel-progress-tracker"
-        class="tab-panel"
-        role="tabpanel"
-        aria-labelledby="tab-progress-tracker"
-        tabindex="0"
-      >
-        <div id="ptControls" class="pt-controls">
-          <label>
-            Project:
-            <select id="ptProject"></select>
-          </label>
-          <button id="ptNewProject">New Project</button>
-          <button id="ptDeleteProject">Delete Project</button>
-          <label>
-            Filter:
-            <select id="ptFilter">
-              <option value="all">All</option>
-              <option value="not_started">Not Started</option>
-              <option value="work_in_progress">In Progress</option>
-              <option value="completed">Completed</option>
-            </select>
-          </label>
-          <button id="ptAddRoot">Add Root Item</button>
-          <button id="ptExport">Export JSON</button>
-          <button id="ptImportBtn">Import JSON</button>
-          <input
-            id="ptImport"
-            type="file"
-            accept=".json"
-            style="display:none"
-          />
-        </div>
-        <div id="ptProjectNotes" class="pt-notes-block">
-          <label for="ptNotes">Project Notes:</label>
-          <textarea id="ptNotes" rows="3"></textarea>
-        </div>
-        <div id="ptTree"></div>
-      </section>
     </div>
 
     <script src="script.js"></script>
-    <script src="progress-tracker.js"></script>
   </body>
 </html>

--- a/progress-tracker.html
+++ b/progress-tracker.html
@@ -1,0 +1,47 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Progress Tracker - Fluid Power Tools</title>
+    <link rel="icon" type="image/x-icon" href="favicon.png" />
+    <link rel="stylesheet" href="styles.css" />
+  </head>
+  <body class="pt-page">
+    <h3>Progress Tracker</h3>
+    <section id="panel-progress-tracker">
+      <div id="ptControls" class="pt-controls">
+        <label>
+          Project:
+          <select id="ptProject"></select>
+        </label>
+        <button id="ptNewProject">New Project</button>
+        <button id="ptDeleteProject">Delete Project</button>
+        <label>
+          Filter:
+          <select id="ptFilter">
+            <option value="all">All</option>
+            <option value="not_started">Not Started</option>
+            <option value="work_in_progress">In Progress</option>
+            <option value="completed">Completed</option>
+          </select>
+        </label>
+        <button id="ptAddRoot">Add Root Item</button>
+        <button id="ptExport">Export JSON</button>
+        <button id="ptImportBtn">Import JSON</button>
+        <input
+          id="ptImport"
+          type="file"
+          accept=".json"
+          style="display:none"
+        />
+      </div>
+      <div id="ptProjectNotes" class="pt-notes-block">
+        <label for="ptNotes">Project Notes:</label>
+        <textarea id="ptNotes" rows="3"></textarea>
+      </div>
+      <div id="ptTree"></div>
+    </section>
+    <script src="progress-tracker.js"></script>
+  </body>
+</html>

--- a/styles.css
+++ b/styles.css
@@ -10,6 +10,9 @@ body {
   display: flex;
   justify-content: center;
 }
+body.pt-page {
+  display: block;
+}
 #container {
   background: #fff;
   padding: 30px 40px 40px;
@@ -28,6 +31,10 @@ h3 {
   margin-bottom: 20px;
   user-select: none;
   text-align: center;
+}
+#ptLink {
+  text-align: center;
+  margin-bottom: 15px;
 }
 
 /* Tabs container */


### PR DESCRIPTION
## Summary
- Remove progress tracker tab from index and link out to a dedicated page
- Add standalone `progress-tracker.html` with existing tracker features
- Adjust styles to allow tracker page to use full width and link styling

## Testing
- `npx --yes htmlhint index.html progress-tracker.html` *(fails: 403 Forbidden)*
- `npx --yes stylelint styles.css` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68c09ab1ebec832fac3471cfe0f40db8