### PR TITLE
Improve progress tracker styling and notes toggle

### DIFF
--- a/progress-tracker.html
+++ b/progress-tracker.html
@@ -17,6 +17,7 @@
         </label>
         <button id="ptNewProject">New Project</button>
         <button id="ptDeleteProject">Delete Project</button>
+        <button id="ptToggleNotes">Hide Notes</button>
         <label>
           Filter:
           <select id="ptFilter">

--- a/progress-tracker.js
+++ b/progress-tracker.js
@@ -88,6 +88,8 @@
   const treeEl = document.getElementById('ptTree');
   const importInput = document.getElementById('ptImport');
   const notesEl = document.getElementById('ptNotes');
+  const notesBlock = document.getElementById('ptProjectNotes');
+  const toggleNotesBtn = document.getElementById('ptToggleNotes');
 
   document
     .getElementById('ptNewProject')
@@ -105,6 +107,10 @@
     .getElementById('ptImportBtn')
     .addEventListener('click', () => importInput.click());
   importInput.addEventListener('change', handleImport);
+  toggleNotesBtn.addEventListener('click', () => {
+    const hidden = notesBlock.classList.toggle('hidden');
+    toggleNotesBtn.textContent = hidden ? 'Show Notes' : 'Hide Notes';
+  });
   notesEl.addEventListener('input', e => {
     projectNotes = e.target.value;
     saveProject();
@@ -269,7 +275,7 @@
     treeEl.innerHTML = `
       <div class="pt-header pt-row">
         <span></span>
-        <span>ID</span>
+        <span>Part Number</span>
         <span>Description</span>
         <span>Progress</span>
         <span>Status</span>
@@ -454,7 +460,7 @@
   }
 
   function addItem(parentId) {
-    const id = prompt('Item number?');
+    const id = prompt('Part number?');
     if (!id) return;
     if (items.some(it => it.id === id)) {
       alert('Exists.');

--- a/styles.css
+++ b/styles.css
@@ -574,6 +574,9 @@ th.sort-desc::after {
 }
 .pt-id {
   width: 80px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 .pt-desc {
   flex: 1;
@@ -597,6 +600,13 @@ th.sort-desc::after {
 }
 .pt-notes.hidden {
   display: none;
+}
+.pt-notes-block {
+  margin: 10px 0;
+}
+.pt-notes-block textarea {
+  width: 100%;
+  resize: vertical;
 }
 .pt-mini {
   padding: 4px 8px;
@@ -623,4 +633,9 @@ th.sort-desc::after {
 .pt-header {
   font-weight: 600;
   border-bottom: 1px solid #ddd;
+  background: #f5f5f5;
+}
+
+.hidden {
+  display: none;
 }


### PR DESCRIPTION
## Summary
- rename ID column and prompts to Part Number
- add control to hide or show project notes
- prevent long part numbers from overlapping descriptions and refine header styling

## Testing
- `npm test` (fails: Missing script: "test")
- `node --check progress-tracker.js`
- `npx htmlhint progress-tracker.html` (fails: 403 403 Forbidden - GET https://registry.npmjs.org/htmlhint)

------
https://chatgpt.com/codex/tasks/task_e_68c09ca1e430832fb042f7359c52050a