### PR TITLE
style: center and evenly space progress tracker columns

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -565,25 +565,25 @@ th.sort-desc::after {
 }
 .pt-row {
   display: grid;
-  grid-template-columns: 1em 80px 1fr 60px 130px 130px auto auto auto;
+  grid-template-columns:
+    1em 1fr 3fr 1fr 1fr 1fr auto auto auto;
   align-items: center;
+  justify-items: center;
   gap: 8px;
   padding: 4px 0;
   min-width: 720px;
   border-bottom: 1px solid #ddd;
 }
+.pt-row > * {
+  text-align: center;
+}
 .pt-id {
-  width: 80px;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
 }
-.pt-desc {
-  flex: 1;
-}
 .pt-progress {
-  width: 60px;
-  text-align: right;
+  text-align: center;
 }
 .pt-toggle {
   cursor: pointer;
@@ -616,6 +616,7 @@ th.sort-desc::after {
   width: 100%;
   padding: 2px 4px;
   font-size: 0.8rem;
+  text-align: center;
 }
 .status-not_started {
   background: #f8d7da;


### PR DESCRIPTION
## Summary
- center progress tracker text and controls
- distribute progress tracker column widths proportionally to content

## Testing
- `npx --yes prettier --check styles.css progress-tracker.html` *(fails: Code style issues found in 2 files)*
- `npx --yes htmlhint progress-tracker.html` *(fails: 403 Forbidden)*
- `npx --yes csslint styles.css` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68c09e9cfe88832f92f5e900b9b32408