### PR TITLE
Remove sample projects and improve progress tracker UX

### DIFF
--- a/progress-tracker.html
+++ b/progress-tracker.html
@@ -16,20 +16,20 @@
           <select id="ptProject"></select>
         </label>
         <button id="ptNewProject">New Project</button>
-        <button id="ptDeleteProject">Delete Project</button>
-        <button id="ptToggleNotes">Hide Notes</button>
+        <button id="ptDeleteProject" disabled>Delete Project</button>
+        <button id="ptToggleNotes" disabled>Show Notes</button>
         <label>
           Filter:
-          <select id="ptFilter">
+          <select id="ptFilter" disabled>
             <option value="all">All</option>
             <option value="not_started">Not Started</option>
             <option value="work_in_progress">In Progress</option>
             <option value="completed">Completed</option>
           </select>
         </label>
-        <button id="ptAddRoot">Add Root Item</button>
-        <button id="ptExport">Export JSON</button>
-        <button id="ptImportBtn">Import JSON</button>
+        <button id="ptAddRoot" disabled>Add Root Item</button>
+        <button id="ptExport" disabled>Export JSON</button>
+        <button id="ptImportBtn" disabled>Import JSON</button>
         <input
           id="ptImport"
           type="file"
@@ -37,9 +37,9 @@
           style="display:none"
         />
       </div>
-      <div id="ptProjectNotes" class="pt-notes-block">
+      <div id="ptProjectNotes" class="pt-notes-block hidden">
         <label for="ptNotes">Project Notes:</label>
-        <textarea id="ptNotes" rows="3"></textarea>
+        <textarea id="ptNotes" rows="3" disabled></textarea>
       </div>
       <div id="ptTree"></div>
     </section>

--- a/styles.css
+++ b/styles.css
@@ -637,6 +637,12 @@ th.sort-desc::after {
   background: #f5f5f5;
 }
 
+.pt-empty {
+  text-align: center;
+  padding: 10px;
+  color: #666;
+}
+
 .hidden {
   display: none;
 }


### PR DESCRIPTION
## Summary
- remove seeded sample projects from progress tracker
- disable project controls until a project is created and show helpful placeholders
- show empty-tree messaging and styling for better guidance

## Testing
- `npm run build:json`


------
https://chatgpt.com/codex/tasks/task_e_68c1809c9fc0832f86ed00c5d375a529