### PR TITLE
Fix progress tracker column alignment and parent styling

### DIFF
--- a/progress-tracker.js
+++ b/progress-tracker.js
@@ -290,6 +290,7 @@
     li.dataset.id = node.id;
     const row = document.createElement('div');
     row.className = 'pt-row status-' + node.status;
+    if (node.children.length) row.classList.add('pt-parent');
 
     const toggle = document.createElement('span');
     toggle.className =

--- a/styles.css
+++ b/styles.css
@@ -563,6 +563,9 @@ th.sort-desc::after {
   list-style: none;
   padding-left: 20px;
 }
+#ptRoot {
+  padding-left: 0;
+}
 .pt-row {
   display: grid;
   grid-template-columns:
@@ -581,6 +584,10 @@ th.sort-desc::after {
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+}
+.pt-parent .pt-id,
+.pt-parent .pt-desc {
+  font-weight: 600;
 }
 .pt-progress {
   text-align: center;


### PR DESCRIPTION
## Summary
- Align progress tracker headers with columns by removing padding on root list
- Highlight parent items by bolding their part numbers and descriptions

## Testing
- `npx htmlhint progress-tracker.html` *(fails: 403 Forbidden)*
- `npx stylelint styles.css` *(fails: 403 Forbidden)*
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68c183540730832f8843b19ac588b9c8