### PR TITLE
Enable JSON import without existing projects

### DIFF
--- a/progress-tracker.html
+++ b/progress-tracker.html
@@ -29,7 +29,7 @@
         </label>
         <button id="ptAddRoot" disabled>Add Root Item</button>
         <button id="ptExport" disabled>Export JSON</button>
-        <button id="ptImportBtn" disabled>Import JSON</button>
+        <button id="ptImportBtn">Import JSON</button>
         <input
           id="ptImport"
           type="file"

--- a/progress-tracker.js
+++ b/progress-tracker.js
@@ -33,7 +33,6 @@
       'ptDeleteProject',
       'ptAddRoot',
       'ptExport',
-      'ptImportBtn',
       'ptToggleNotes',
       'ptFilter',
       'ptNotes'
@@ -41,11 +40,13 @@
       const el = document.getElementById(id);
       if (el) el.disabled = disabled;
     });
+    const importBtn = document.getElementById('ptImportBtn');
+    if (importBtn) importBtn.disabled = false;
     if (disabled) {
       notesBlock.classList.add('hidden');
       toggleNotesBtn.textContent = 'Show Notes';
       treeEl.innerHTML =
-        '<p class="pt-empty">Create a project to get started.</p>';
+        '<p class="pt-empty">Create or import a project to get started.</p>';
     } else {
       notesBlock.classList.remove('hidden');
       toggleNotesBtn.textContent = 'Hide Notes';


### PR DESCRIPTION
## Summary
- Keep import button active even when no project is loaded
- Update empty-state text to suggest creating or importing a project
- Remove disabled attribute from import button markup

## Testing
- `node --check progress-tracker.js`
- `npx html-validate progress-tracker.html` *(fails: 403 Forbidden)*
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68c1e9f93464832fb545d79cdd4edc0e